### PR TITLE
fix: double-slash in api calls due to domain to url conversion

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -29,7 +29,7 @@ export async function fetchImageToBytes(url: string) {
 }
 
 export function domainToUrl(domain: string) {
-    return `https://${domain}/`
+    return `https://${domain}`
 }
 
 export function genCallBackUrl(instanceDomain: string) {


### PR DESCRIPTION
skymoth sends //api/v1/apps to my server, which is not correctly handled by either my reverse proxy or GoToSocial.